### PR TITLE
64bit-preparation: Murdock test failure + Bug fix for LWIP

### DIFF
--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -35,7 +35,7 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#define MTD_FLASHPAGE_END_ADDR     ((uint32_t) CPU_FLASH_BASE + (FLASHPAGE_NUMOF * FLASHPAGE_SIZE))
+#define MTD_FLASHPAGE_END_ADDR     ((uintptr_t) CPU_FLASH_BASE + (FLASHPAGE_NUMOF * FLASHPAGE_SIZE))
 
 static int _init(mtd_dev_t *dev)
 {
@@ -44,11 +44,14 @@ static int _init(mtd_dev_t *dev)
     assert(dev->pages_per_sector * dev->page_size == FLASHPAGE_SIZE);
     assert(!(super->offset % dev->pages_per_sector));
 
-    assert((uintptr_t)flashpage_addr(super->offset / dev->pages_per_sector) >= CPU_FLASH_BASE);
+    /* Use separate variable to avoid '>= 0 is always true' warning */
+    static const uintptr_t cpu_flash_base = CPU_FLASH_BASE;
+
+    assert((uintptr_t)flashpage_addr(super->offset / dev->pages_per_sector) >= cpu_flash_base);
     assert((uintptr_t)flashpage_addr(super->offset / dev->pages_per_sector)
            + dev->pages_per_sector * dev->page_size * dev->sector_count <= MTD_FLASHPAGE_END_ADDR);
     assert((uintptr_t)flashpage_addr(super->offset / dev->pages_per_sector)
-           + dev->pages_per_sector * dev->page_size * dev->sector_count > CPU_FLASH_BASE);
+           + dev->pages_per_sector * dev->page_size * dev->sector_count > cpu_flash_base);
     return 0;
 }
 

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -616,7 +616,7 @@ ssize_t lwip_sock_sendv(struct netconn *conn, const iolist_t *snips,
     struct netconn *tmp;
     struct netbuf *buf = NULL;
     size_t payload_len = 0;
-    int res;
+    ssize_t res;
     err_t err= ERR_OK;
     u16_t remote_port = 0;
 

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -51,26 +51,26 @@ extern "C" {
 /**
  * @brief   Size of a word in bits
  *
- * @details Depending on architecture, this can have a value of 8, 16, or 32
+ * @details Depending on architecture, this can have a value of 8, 16, 32, or 64
  */
 #define ARCHITECTURE_WORD_BITS      <NUM>
 /**
  * @brief   Size of a word in bytes
  *
- * @details Depending on architecture, this can have a value or 1, 2, or 4.
+ * @details Depending on architecture, this can have a value or 1, 2, 4, or 8.
  */
 #define ARCHITECTURE_WORD_BYTES     <NUM>
 /**
  * @brief   Word sized unsigned integer
  *
- * @details Synonym to `uint8_t`, `uint16_t` or `uint32_t` depending on
- *          architecture
+ * @details Synonym to `uint8_t`, `uint16_t`, `uint32_t`, or `uint64_t`
+ *          depending on architecture
  */
 typedef uint<num>_t uword_t;
 /**
  * @brief   Word sized signed integer
  *
- * @details Synonym to `int8_t`, `int16_t` or `int32_t` depending on
+ * @details Synonym to `int8_t`, `int16_t`, `int32_t`, or `int64_t` depending on
  *          architecture
  *
  * @note    This type is pronounce es-word-tea. When slaying dragons, this is


### PR DESCRIPTION
### Contribution description

- Fix for failed murdock test
```
drivers/mtd_flashpage/mtd_flashpage.c:48:77: error: comparison of unsigned expression in '>= 0' is always true [-Werror=type-limits]
   48 |     assert((uintptr_t)flashpage_addr(super->offset / dev->pages_per_sector) >= CPU_FLASH_BASE);
```
- Fix for `pkg/lwip/contrib/sock/lwip_sock.c`
- Missing doxygen documentation

### Testing procedure

`BOARD=adafruit-itsybitsy-m4 make -C tests/sys/fido2_ctap`
`make -C tests/pkg/lwip_sock_tcp all test`
