### PR TITLE
examples/dtls-sock: Revert changes due to separate PR

### DIFF
--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -7,6 +7,9 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+# TinyDTLS only has support for 32-bit architectures ATM
+FEATURES_REQUIRED += arch_32bit
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += netdev_default

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -1,9 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
-    arduino-leonardo \
-    arduino-mega2560 \
-    arduino-nano \
-    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill-stm32f103c8 \
     blackpill-stm32f103cb \
@@ -11,13 +7,11 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
     calliope-mini \
-    derfmega12 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     lsn50 \
-    mega-xplained \
     microbit \
     nrf51dongle \
     nrf6310 \
@@ -44,6 +38,4 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     stm32mp157c-dk2 \
     yunjia-nrf51822 \
-    waspmote-pro \
-    z1 \
     #


### PR DESCRIPTION
### Contribution description

~Compiled `examples/dtls-sock` with all boards and added all boards with insufficient memory in `Makefile.ci`.
This should fix the murdock test.~

Created separate PR (#20196) as this is technically a general bug.

