### PR TITLE
drivers: Missing size_t format specifiers

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -645,8 +645,8 @@ static int _atwinc15x0_get(netdev_t *netdev, netopt_t opt, void *val,
     assert(dev);
     assert(dev == atwinc15x0);
 
-    DEBUG("%s dev=%p opt=%u val=%p max_len=%lu\n", __func__,
-          (void *)netdev, opt, val, (unsigned long)max_len);
+    DEBUG("%s dev=%p opt=%u val=%p max_len=%" PRIuSIZE "\n", __func__,
+          (void *)netdev, opt, val, max_len);
 
     switch (opt) {
         case NETOPT_IS_WIRED:
@@ -755,8 +755,8 @@ static int _atwinc15x0_set(netdev_t *netdev, netopt_t opt, const void *val,
 {
     atwinc15x0_t *dev = (atwinc15x0_t *)netdev;
 
-    DEBUG("%s dev=%p opt=%u val=%p max_len=%u\n", __func__,
-          (void *)netdev, opt, val, (unsigned)max_len);
+    DEBUG("%s dev=%p opt=%u val=%p max_len=%" PRIuPTR "\n", __func__,
+          (void *)netdev, opt, val, max_len);
 
     int ret;
     switch (opt) {

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -292,7 +292,7 @@ void lcd_ll_release(lcd_t *dev)
 void lcd_ll_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
                       size_t len)
 {
-    DEBUG("[%s] command 0x%02x (%lu) ", __func__, cmd, (unsigned long)len);
+    DEBUG("[%s] command 0x%02x (%" PRIuSIZE ") ", __func__, cmd, len);
     if (IS_USED(ENABLE_DEBUG) && len) {
         for (uint8_t i = 0; i < len; i++) {
              DEBUG("0x%02x ", data[i]);
@@ -310,7 +310,7 @@ void lcd_ll_read_cmd(lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
 {
     assert(len);
 
-    DEBUG("[%s] command 0x%02x (%lu) ", __func__, cmd, (unsigned long)len);
+    DEBUG("[%s] command 0x%02x (%" PRIuSIZE ") ", __func__, cmd, len);
 
     lcd_ll_cmd_start(dev, cmd, true);
     lcd_ll_read_bytes(dev, false, data, len);

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -323,8 +323,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     }
     /* drop frame, content in buf becomes invalid and return -ENOBUFS */
     if (len < frame_len) {
-        DEBUG("[nrf24l01p_ng] Buffer too small: %u < %u, dropping frame\n",
-              (unsigned)len, frame_len);
+        DEBUG("[nrf24l01p_ng] Buffer too small: %" PRIuSIZE " < %u, dropping frame\n",
+              len, frame_len);
         uint8_t garbage[pl_width];
         nrf24l01p_ng_read_rx_payload(dev, garbage, pl_width);
         return -ENOBUFS;

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -78,7 +78,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         return 0;
     }
 
-    DEBUG("[sx126x] netdev: sending packet now (size: %u).\n", (unsigned)pos);
+    DEBUG("[sx126x] netdev: sending packet now (size: %" PRIuSIZE ").\n", pos);
     sx126x_set_lora_payload_length(dev, pos);
 
     state = NETOPT_STATE_TX;

--- a/drivers/sx1280/sx1280_netdev.c
+++ b/drivers/sx1280/sx1280_netdev.c
@@ -73,7 +73,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         return 0;
     }
 
-    DEBUG("[sx1280] netdev: sending packet now (size: %u).\n", (unsigned)pos);
+    DEBUG("[sx1280] netdev: sending packet now (size: %" PRIuSIZE ").\n", pos);
     sx1280_set_lora_payload_length(dev, pos);
 
     state = NETOPT_STATE_TX;


### PR DESCRIPTION
### Contribution description

Somehow I missed to commit these changes. (size_t prints without cast in drivers)
I need a break from looking at print statements :)

### Testing procedure

Set the appropriate `ENABLE_DEBUG 1` and compile the driver tests.